### PR TITLE
Refactor parser.rs

### DIFF
--- a/src/archarchive/parser.rs
+++ b/src/archarchive/parser.rs
@@ -47,14 +47,22 @@ pub async fn parse_years() -> anyhow::Result<Vec<String>> {
     Ok(years)
 }
 pub async fn parse_months(year: &str) -> anyhow::Result<Vec<String>> {
-    let html: String = reqwest::get(&build_url(year, Some(month), None)).await?.text().await?;
+    let html: String = reqwest::get(&build_url(year, None, None))
+        .await?
+        .text()
+        .await?;
+
     let fragment = Html::parse_fragment(&html);
     let months: Vec<String> = get_elements(&fragment)?;
 
     Ok(months)
 }
 pub async fn parse_days(year: &str, month: &str) -> anyhow::Result<Vec<String>> {
-    let html: String = reqwest::get(&build_url(year, Some(month), Some(day))).await?.text().await?;
+    let html: String = reqwest::get(&build_url(year, Some(month), None))
+        .await?
+        .text()
+        .await?;
+
     let fragment = Html::parse_fragment(&html);
     let days: Vec<String> = get_elements(&fragment)?;
 

--- a/src/archarchive/parser.rs
+++ b/src/archarchive/parser.rs
@@ -2,6 +2,7 @@ use anyhow::{anyhow, Result};
 use scraper::{Html, Selector};
 use crate::archarchive::ENDPOINT;
 
+
 fn get_elements(fragment: &scraper::Html) -> anyhow::Result<Vec<String>> {
     let mut elements: Vec<String> = vec![];
 
@@ -19,6 +20,14 @@ fn get_elements(fragment: &scraper::Html) -> anyhow::Result<Vec<String>> {
 
     Ok(elements)
 }
+fn build_url(year: &str, month: Option<&str>, day: Option<&str>) -> String {
+    match (month, day) {
+        (Some(m), Some(d)) => format!("{}/{}/{}/", ENDPOINT, year, m, d),
+        (Some(m), None)    => format!("{}/{}/", ENDPOINT, year, m),
+        (None, None)       => format!("{}/", ENDPOINT),
+        _ => unreachable!()
+    }
+}
 pub async fn parse_years() -> anyhow::Result<Vec<String>> {
     let html: String = reqwest::get(ENDPOINT)
         .await?
@@ -28,29 +37,22 @@ pub async fn parse_years() -> anyhow::Result<Vec<String>> {
     let fragment = Html::parse_fragment(&html);
     let mut years: Vec<String> = get_elements(&fragment)?;
 
-    for _ in 0..3 {
+    const FOOTER_LINKS_COUNT: usize = 3;
+    for _ in 0..FOOTER_LINKS_COUNT {
         years.pop();
     }
 
     Ok(years)
 }
 pub async fn parse_months(year: &str) -> anyhow::Result<Vec<String>> {
-    let html: String = reqwest::get(&format!("{}/{}", ENDPOINT, year))
-        .await?
-        .text()
-        .await?;
-
+    let html: String = reqwest::get(&build_url(year, Some(month), None)).await?.text().await?;
     let fragment = Html::parse_fragment(&html);
     let months: Vec<String> = get_elements(&fragment)?;
 
     Ok(months)
 }
 pub async fn parse_days(year: &str, month: &str) -> anyhow::Result<Vec<String>> {
-    let html: String = reqwest::get(&format!("{}/{}/{}", ENDPOINT, year, month))
-        .await?
-        .text()
-        .await?;
-
+    let html: String = reqwest::get(&build_url(year, Some(month), Some(day))).await?.text().await?;
     let fragment = Html::parse_fragment(&html);
     let days: Vec<String> = get_elements(&fragment)?;
 

--- a/src/archarchive/parser.rs
+++ b/src/archarchive/parser.rs
@@ -11,9 +11,11 @@ fn get_elements(fragment: &scraper::Html) -> anyhow::Result<Vec<String>> {
 
     for element in fragment.select(&selector) {
         if let Some(href) = element.attr("href") {
-            let element = href[..href.len() - 1].trim();
-            if element != ".." {
-                elements.push(element.to_string());
+            if href.ends_with('/') && href != '../' {
+                let element = href.trim_end_matches('/');
+                if element != ".." {
+                    elements.push(element.to_string());
+                }
             }
         }
     }


### PR DESCRIPTION
1. Replaced the magic number in a 'parse_years' function with a constant 'FOOTER_LINKS_COUNT'
2. Added the 'build_url' function to centralize URL construction across parsing functions ('parse_months', 'parse_days')
3. Maintained safe href parsing using `trim_end_matches('/') to avoid panics from manual string slicing